### PR TITLE
Pass state.env in `footnote_reference_close` blocks

### DIFF
--- a/footnotes/mod.ts
+++ b/footnotes/mod.ts
@@ -257,6 +257,7 @@ export default function footNotes(md: any, userOptions: Partial<Options> = {}) {
         currentFootnote!.content = md.renderer.render(
           currentTokens,
           state.md.options,
+          state.env
         );
         currentTokens = undefined;
         return false;


### PR DESCRIPTION
Fixes a very small edge case that I encountered where not passing this doesn't allow other defined rules to get and set items from the page's data.