### PR TITLE
Export Footnote interface for `footnotes` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.12.0 - Unreleased
+### Added
+- `footnotes` plugin: export `Footnote` type.
+
 ## [0.11.1] - 2026-01-29
 ### Fixed
 - Use Lume's slugifier by default

--- a/footnotes/mod.ts
+++ b/footnotes/mod.ts
@@ -20,6 +20,14 @@ export interface Options {
   referenceFn: (label: string, attrs: Record<string, string>) => string;
 }
 
+export interface Footnote {
+  id: string;
+  label?: string;
+  content?: string;
+  refId?: string;
+  refIds?: string[];
+}
+
 export const defaults: Options = {
   key: "footnotes",
   idPrefix: "fn-",
@@ -267,7 +275,7 @@ export default function footNotes(md: any, userOptions: Partial<Options> = {}) {
       return;
     }
 
-    let currentFootnote: Footnote | undefined;
+    let currentFootnote: FootnoteItem | undefined;
     let currentTokens: any[] | undefined;
 
     state.tokens = state.tokens.filter(function (tok: any) {
@@ -322,12 +330,12 @@ export default function footNotes(md: any, userOptions: Partial<Options> = {}) {
         refIds,
         label: footnote.label,
         content: footnote.content,
-      };
+      } satisfies Footnote;
     });
   });
 }
 
-interface Footnote {
+interface FootnoteItem {
   id: number;
   subId: number;
   label?: string;
@@ -335,9 +343,9 @@ interface Footnote {
   tokens?: any[];
 }
 
-function getFootnotes(state: any): Map<number, Footnote> {
+function getFootnotes(state: any): Map<number, FootnoteItem> {
   if (!state.env.fn) {
-    state.env.fn = new Map<number, Footnote>();
+    state.env.fn = new Map<number, FootnoteItem>();
   }
 
   return state.env.fn;


### PR DESCRIPTION
This is useful for people using this plugin and writing their layout files in Typescript or TSX.

I want to keep the exported interface aligned with the exported data key `footnotes`, so the internal interface is renamed to `FootnoteItem` (I'm not creative with naming things).